### PR TITLE
Remove semicolons when removing bound fn

### DIFF
--- a/lib/rules/no-constructor-bind.js
+++ b/lib/rules/no-constructor-bind.js
@@ -124,7 +124,7 @@ module.exports = {
             if (!definition) return
 
             return [
-              fixer.remove(node),
+              fixer.remove(node.parent),
               fixer.replaceText(definition, convertToArrowFunction(definition))
             ]
           }

--- a/tests/lib/rules/no-constructor-bind.js
+++ b/tests/lib/rules/no-constructor-bind.js
@@ -91,6 +91,14 @@ ruleTester.run('no-constructor-bind', rule, {
          class secondClass { constructor() {  } myFunction = () => {} }`,
       errors: [error, error]
     },
+    {
+      // Should handle semicolons.
+      code:
+        'class myClass { constructor() { this.myFunction = this.myFunction.bind(this); }; myFunction() {}; };',
+      output:
+        'class myClass { constructor() {  }; myFunction = () => {}; };',
+      errors: [error]
+    },
     // Should handle multi-line params
     {
       code:


### PR DESCRIPTION
Fixes #42

A note: it looks like it still doesn't fix all instances in a single pass. The fixer may only be performing a single fix each run, which seems really wasteful. This is probably because the ranges overlap, and I'm not sure there's a way to get around this.