### PR TITLE
Handle anonymous class definitions

### DIFF
--- a/lib/rules/no-constructor-bind.js
+++ b/lib/rules/no-constructor-bind.js
@@ -21,7 +21,7 @@ module.exports = {
   },
 
   create: function(context) {
-    let thisClass = {}
+    let stack = []
 
     //----------------------------------------------------------------------
     // Helpers
@@ -71,6 +71,7 @@ module.exports = {
     }
 
     function findMethodDef(name) {
+      const thisClass = stack[stack.length - 1]
       return thisClass.classMethods[name]
     }
 
@@ -118,19 +119,21 @@ module.exports = {
     }
 
     function logBoundMethod(node) {
+      const thisClass = stack[stack.length - 1]
       thisClass.boundMethods.push(node)
     }
 
     function logMethodDefinition(node) {
+      const thisClass = stack[stack.length - 1]
       thisClass.classMethods[node.key.name] = node
     }
 
     function init() {
-      thisClass.boundMethods = []
-      thisClass.classMethods = {}
+      stack.push({ boundMethods: [], classMethods: {} })
     }
 
     function report() {
+      const thisClass = stack[stack.length - 1]
       thisClass.boundMethods.forEach(node => {
         context.report({
           node: node,
@@ -147,7 +150,7 @@ module.exports = {
         })
       })
 
-      thisClass = {}
+      stack.pop()
     }
 
     const constructorDefinition = [

--- a/tests/lib/rules/no-constructor-bind.js
+++ b/tests/lib/rules/no-constructor-bind.js
@@ -36,7 +36,9 @@ ruleTester.run('no-constructor-bind', rule, {
     'firstClass = class { myFunction = () => {} }; secondClass = class { myFunction = () => {} }',
 
     'class myClass { constructor() { this.myFn = this.fns.myFn.bind(this) } fns = { myFn: function() {} } }',
-    'class myClass { constructor() { this.myFunction = myFunction.bind(this) } }'
+    'class myClass { constructor() { this.myFunction = myFunction.bind(this) } }',
+
+    'class myClass { myFunction() { return class { constructor() {} } } }'
   ],
 
   invalid: [
@@ -122,6 +124,14 @@ ruleTester.run('no-constructor-bind', rule, {
             arg3
           ) => {}
         }`,
+      errors: [error]
+    },
+    {
+      // Should handle anonymous classes
+      code:
+        'class myClass { constructor() { return class { constructor() { this.myFunction = this.myFunction.bind(this) } myFunction() {} } } }',
+      output:
+        'class myClass { constructor() { return class { constructor() {  } myFunction = () => {} } } }',
       errors: [error]
     }
   ]


### PR DESCRIPTION
Since a class might be defined within a class, push/pop a stack when
walking down/up the AST.

Fixes #48 